### PR TITLE
1.3.5 Hotfix

### DIFF
--- a/Assets/Scripts/Builds/SceneBuild.cs
+++ b/Assets/Scripts/Builds/SceneBuild.cs
@@ -71,9 +71,11 @@ namespace Protobot.Builds {
         private static GameObject GenerateObject(ObjectData objectData, BuildData buildData)
         {
             GameObject generatedObject = PartsManager.GeneratePart(objectData.partId, objectData.GetPos(), objectData.GetRot());
-            string[] versionsNoColor = new string[] { "1.0", "1.1", "1.1.1", "1.2", "1.3", "1.3.1", "1.3.2", "1.3.3", "1.3.4" };
-            if(!versionsNoColor.Contains(buildData.version))
-            {
+            //there are only 2 versions of Protobot legacy publicly released that I could find most before Beta 1.3.1 are just guesses
+            string[] versionsNoColor = new string[] {"1.0", "1.1", "1.1.1", "Beta 1.2", "Beta 1.3", "Beta 1.3.1", "1.3.2", "1.3.3", "1.3.4" };
+            //Debug.Log(buildData.version);    
+            if(!versionsNoColor.Contains(buildData.version) && buildData.version != null)
+            { 
                 generatedObject.GetComponent<Renderer>().material.color = objectData.GetColor();
             }
             return generatedObject;


### PR DESCRIPTION
Going from legacy Protobot to the newest version caused a large majority of parts to become black and would be unable to be changed

Any version of 1.3.5 (including prereleases) downloaded before night of 11/19/24 will have this issue

if you saved a bot from that short period where 1.3.5 was released with this issue just save in this version which DOES NOT SAVE ANY COLORING: https://cdn.discordapp.com/attachments/1216916900450271322/1308603187380359270/Protobot.Rebuilt-1.3.5-COLORCLEAR.zip?ex=673f33f0&is=673de270&hm=a218ec7283f6ebe1365cd03a115a4155e322518db3082325778a3cebe4933720&

This resolves #50