### PR TITLE
Fix/shaft decimal input

### DIFF
--- a/Assets/Prefabs/Add Menu/Param Display.prefab
+++ b/Assets/Prefabs/Add Menu/Param Display.prefab
@@ -640,7 +640,7 @@ MonoBehaviour:
   m_LineType: 0
   m_HideMobileInput: 0
   m_CharacterValidation: 0
-  m_CharacterLimit: 3
+  m_CharacterLimit: 0
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/ParamDisplay.cs
+++ b/Assets/Scripts/ParamDisplay.cs
@@ -7,6 +7,16 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace Protobot {
+    /// <summary>
+    /// UI component that displays and manages a single part parameter (e.g. shaft length, type).
+    /// Supports two display modes:
+    ///   - Dropdown: for parameters with a fixed list of options (e.g. "Normal" / "High Strength")
+    ///   - Custom input field: for parameters the user types in (e.g. length in inches or holes)
+    ///
+    /// Clamping to min/max limits is only applied when the user finishes typing (on end edit),
+    /// NOT on every keystroke — this prevents the bug where typing "12.2" would be immediately
+    /// cut to "12" because the mid-type value temporarily exceeded the integer limit.
+    /// </summary>
     public class ParamDisplay : MonoBehaviour, IScrollHandler {
         [SerializeField] private Text title;
         [SerializeField] private Dropdown dropdown;
@@ -25,13 +35,21 @@ namespace Protobot {
             dropdown.onValueChanged.AddListener(index => {
                 OnUpdateValue?.Invoke(dropdown.options[index].text);
             });
-            
+
+            // While the user is typing, only update the parameter value if the input
+            // is a valid number. We do NOT clamp here — clamping on every keystroke
+            // causes a bug where values like "12.2" are immediately cut to "12" because
+            // the mid-type value exceeds the integer limit before the decimal is finished.
             customInput.onValueChanged.AddListener(inputText => {
-                if (inputText.Length > 0)
-                    OnUpdateValue?.Invoke(ClampCustomInput(parameter, inputText));
+                if (inputText.Length > 0 && float.TryParse(inputText, out _))
+                    OnUpdateValue?.Invoke(inputText);
             });
-            
+
+            // Once the user finishes editing (presses Enter or clicks away),
+            // clamp the value to the allowed min/max range and refresh the display.
             customInput.onEndEdit.AddListener(inputText => {
+                if (inputText.Length > 0 && float.TryParse(inputText, out _))
+                    OnUpdateValue?.Invoke(ClampCustomInput(parameter, inputText));
                 customInput.SetTextWithoutNotify(parameter.value);
             });
         }
@@ -81,20 +99,34 @@ namespace Protobot {
             }
         }
 
-        private string ClampCustomInput(Parameter p, String value) {
-            float valueFloat = float.Parse(value);
-            
+        /// <summary>
+        /// Clamps a user-typed string value to the parameter's allowed min/max range.
+        /// Returns the clamped value as a string, or the parameter's default if unparseable.
+        /// Uses TryParse to safely handle any malformed input without throwing exceptions.
+        /// </summary>
+        private string ClampCustomInput(Parameter p, string value) {
+            if (!float.TryParse(value, out float valueFloat))
+                return p.customDefault;
+
             if (valueFloat > p.customLimits.y) return p.customLimits.y.ToString();
             if (valueFloat < p.customLimits.x) return p.customLimits.x.ToString();
-            
+
             return value;
         }
 
+        /// <summary>
+        /// Handles mouse scroll wheel input on the parameter display.
+        /// Scrolling up/down increments or decrements the value by 1 (for custom inputs)
+        /// or moves to the next/previous dropdown option.
+        /// </summary>
         public void OnScroll(PointerEventData eventData) {
             int dir = (eventData.scrollDelta.y < 1) ? -1 : 1;
-            
+
             if (parameter.custom) {
-                float newVal = float.Parse(parameter.value) + dir;
+                // Use TryParse to safely read the current value before adding scroll delta
+                if (!float.TryParse(parameter.value, out float currentVal)) return;
+
+                float newVal = currentVal + dir;
 
                 if (newVal >= parameter.customLimits.x && newVal <= parameter.customLimits.y)
                     customInput.text = newVal.ToString();


### PR DESCRIPTION
TL:DR
Shaft sizes can not be longer than 3 digits, previously if you tried to input 1.52" it would limit you at 1.5"
Shaft size maximum is still 12" due to VEX not creating shafts longer than 12". This can be discussed later though.

Clamping now only applies when the user finishes editing (onEndEdit),
not on every keystroke (onValueChanged). Previously, typing a value
like 12.2 would instantly snap back to 12 because 12.2 exceeded the
max limit before the full decimal was entered.

Also replaced float.Parse with float.TryParse throughout to prevent
crashes on malformed input. Added XML doc comments for future contributors.

The Param Display prefab had m_CharacterLimit set to 3, which meant
users could only type 3 characters (e.g. "2.5" or "12") and could not
enter values like "2.564" or "12.2" even when under the allowed range.
Changed to 0 (unlimited) so any valid decimal can be entered.
